### PR TITLE
Implement Vi Count Prefixes for Movement

### DIFF
--- a/src/patterns/commands.rs
+++ b/src/patterns/commands.rs
@@ -47,6 +47,8 @@ pub enum Command {
     ExInput(char),
     /// Remove last character from Ex buffer (Backspace)
     ExBackspace,
+    /// Add digit to count buffer in Normal mode
+    CountInput(char),
     /// Unknown/invalid command
     Unknown,
 }
@@ -66,6 +68,7 @@ pub fn parse_normal_command(c: char) -> Command {
         'k' => Command::Move(Direction::Up),
         'l' => Command::Move(Direction::Right),
         ':' => Command::EnterExMode,
+        '0'..='9' => Command::CountInput(c),
         _ => Command::Unknown,
     }
 }

--- a/src/patterns/modes.rs
+++ b/src/patterns/modes.rs
@@ -6,7 +6,7 @@
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Mode {
     /// Normal mode - movement and commands (default)
-    Normal,
+    Normal { count_buffer: String },
     /// Insert mode - text entry (future)
     Insert,
     /// Ex command mode - colon commands with buffer
@@ -15,17 +15,35 @@ pub enum Mode {
 
 impl Default for Mode {
     fn default() -> Self {
-        Mode::Normal
+        Mode::Normal {
+            count_buffer: String::new(),
+        }
     }
 }
 
 impl Mode {
-    /// Get display string for mode
-    pub fn display(&self) -> String {
+    /// Get display string for mode indicator
+    pub fn mode_name(&self) -> &str {
         match self {
-            Mode::Normal => "-- NORMAL --".to_string(),
-            Mode::Insert => "-- INSERT --".to_string(),
-            Mode::Ex { command_buffer } => format!(":{}", command_buffer),
+            Mode::Normal { .. } => "-- NORMAL --",
+            Mode::Insert => "-- INSERT --",
+            Mode::Ex { .. } => "-- COMMAND --",
+        }
+    }
+
+    /// Get pending keys to display (count buffer in Normal mode, empty otherwise)
+    pub fn pending_keys(&self) -> &str {
+        match self {
+            Mode::Normal { count_buffer } => count_buffer,
+            _ => "",
+        }
+    }
+
+    /// Get command line text (for Ex mode, shown below mode indicator without border)
+    pub fn command_line(&self) -> Option<String> {
+        match self {
+            Mode::Ex { command_buffer } => Some(format!(":{}", command_buffer)),
+            _ => None,
         }
     }
 
@@ -38,6 +56,14 @@ impl Mode {
     pub fn command_buffer(&self) -> Option<&str> {
         match self {
             Mode::Ex { command_buffer } => Some(command_buffer),
+            _ => None,
+        }
+    }
+
+    /// Get count buffer if in Normal mode
+    pub fn count_buffer(&self) -> Option<&str> {
+        match self {
+            Mode::Normal { count_buffer } => Some(count_buffer),
             _ => None,
         }
     }

--- a/tests/component_movement.rs
+++ b/tests/component_movement.rs
@@ -41,6 +41,46 @@ fn player_can_move_with_hjkl_commands() {
 }
 
 #[test]
+fn player_can_use_count_prefixes_for_movement() {
+    let mut game = VitalisGame::start();
+
+    // Player starts at world origin
+    assert_eq!(game.world_position(), (0, 0), "Player should start at origin");
+
+    // Move right 5 times with '5l'
+    game.type_text("5l");
+    assert_eq!(
+        game.world_position(),
+        (5, 0),
+        "Player should move right 5 times to (5, 0)"
+    );
+
+    // Move down 3 times with '3j'
+    game.type_text("3j");
+    assert_eq!(
+        game.world_position(),
+        (5, 3),
+        "Player should move down 3 times to (5, 3)"
+    );
+
+    // Move left 2 times with '2h'
+    game.type_text("2h");
+    assert_eq!(
+        game.world_position(),
+        (3, 3),
+        "Player should move left 2 times to (3, 3)"
+    );
+
+    // Move up 10 times with '10k'
+    game.type_text("10k");
+    assert_eq!(
+        game.world_position(),
+        (3, -7),
+        "Player should move up 10 times to (3, -7)"
+    );
+}
+
+#[test]
 fn player_quits_with_colon_q_command() {
     let mut game = VitalisGame::start();
 


### PR DESCRIPTION
# Implement Vi Count Prefixes for Movement

## 🎯 What
Players can now use vi-style count prefixes to repeat movement commands. Typing `5h` moves left 5 times, `10j` moves down 10 times, and so on. The interface shows pending keys in the bottom right corner as you type them, exactly like vi does. Mode names are always visible at the bottom of the screen (NORMAL, INSERT, COMMAND) with Ex commands displayed on a separate borderless line below the mode indicator.

## 🤔 Why
Vi users expect count prefixes to work for all movement commands. This is fundamental to vi muscle memory and dramatically improves navigation efficiency. Without count prefixes, the interface feels incomplete and forces players to press keys repeatedly instead of using the elegant brevity that defines the vi experience.

## ⚙️ How
The architecture adds a count buffer to Normal mode state that accumulates digit characters as they are typed. When a movement command executes, it parses the count buffer as a u32 integer and applies the movement operation that many times, then clears the buffer. The display system shows the pending count and command key on the right side of the mode indicator bar, matching vi behavior. The mode display was restructured to always show mode names using proper vi terminology (NORMAL, COMMAND) and Ex mode commands now appear on a separate borderless line below the mode bar for authentic vi layout.

## 📋 Definition of Done
- [x] Component tests demonstrate working user journeys
- [x] Layered tests verify bounded context behavior
- [x] All domain concepts use ubiquitous language
- [x] No external dependencies leak into domain core
- [x] Documentation reflects domain changes
- [x] Commits follow conventional format

🤖 Generated with [Claude Code](https://claude.com/claude-code)